### PR TITLE
[SUP-93] fix profile name issue on rivers import

### DIFF
--- a/rivery_cli/cli/activities.py
+++ b/rivery_cli/cli/activities.py
@@ -76,7 +76,7 @@ def download_run_logs(ctx, **kwargs):
     run_id = kwargs.get('runid')
 
     click.echo(f'Starting to download logs for run id {run_id} in profile: {profile_name}')
-    rivery_client = client.Client(name=profile_name, profile=profile_name)
+    rivery_client = client.Client(profile=profile_name, debug=ctx.get('DEBUG'))
     session = rivery_client.session
 
     click.echo(f'Downloading logs of run id "{run_id}"')

--- a/rivery_cli/cli/rivers.py
+++ b/rivery_cli/cli/rivers.py
@@ -43,12 +43,9 @@ def push(ctx, *args, **kwargs):
     Push current yaml paths into a rivers in the platform.
     """
     profile_name = ctx.get('PROFILE')
-    rivery_client = client.Client(name=profile_name)
+    rivery_client = client.Client(profile=profile_name, debug=ctx.get('DEBUG'))
     session = rivery_client.session
-    if ctx.get('DEBUG') is True:
-        click.secho(f'Profile details: \n' +
-                    ",\n".join(["{}={}".format(key, val) for key, val in (rivery_client.credentials or {}).items()]),
-                    fg='magenta')
+
     all_rivers = {}
     paths = kwargs.get('paths', '')
     for path in paths.split(','):
@@ -204,14 +201,9 @@ def import_(ctx, *args, **kwargs):
     # get profile name
     profile_name = ctx['PROFILE']
     # make client and session
-    click.echo(f'Connecting to river. Profile: {profile_name}', nl=True)
-    rivery_client = client.Client(name=profile_name, force_new_session=True)
+    click.echo(f'Connecting to rivery. Profile: {profile_name}', nl=True)
+    rivery_client = client.Client(profile=profile_name, force_new_session=True, debug=ctx.get('DEBUG'))
     session = rivery_client.session
-
-    if ctx.get('DEBUG') is True:
-        click.secho(f'Profile details: \n' +
-                    ",\n".join(["{}={}".format(key, val) for key, val in (rivery_client.credentials or {}).items()]),
-                    fg='magenta')
 
     if session:
         # Get the rivers list by the filter
@@ -317,7 +309,7 @@ def run(ctx, **kwargs):
         raise click.ClickException('Please provide one of the above - riverId or entityName')
     # get profile name
     profile_name = ctx['PROFILE']
-    rivery_client = client.Client(name=profile_name)
+    rivery_client = client.Client(profile=profile_name, debug=ctx.get('DEBUG'))
 
     session = rivery_client.session
     try:
@@ -400,7 +392,7 @@ def wait_for_end(session, run_id, timeout=3600 * 2):
 def check_run(ctx, **kwargs):
     """ Check the run status by runId """
     profile_name = ctx.get('PROFILE')
-    rivery_client = client.Client(name=profile_name, profile=profile_name)
+    rivery_client = client.Client(profile=profile_name, debug=ctx.get('DEBUG'))
     session = rivery_client.session
     run_id = kwargs.get('runid')
     timeout = kwargs.get('timeout') or 3600 * 2

--- a/rivery_cli/client.py
+++ b/rivery_cli/client.py
@@ -1,3 +1,5 @@
+import pprint
+
 from rivery_cli import RiverySession
 import os
 from rivery_cli import global_keys
@@ -69,8 +71,11 @@ class Client:
 
         self.token = kwargs.get('token')
         self.debug = kwargs.get('debug') or False
+        self.profile = kwargs.get('profile') or 'default'
         self.stack_path = kwargs.get('stack_path') or '.'
-        self.stack_name = kwargs.get('name') or kwargs.get('stack_name') or kwargs.get('client_name')
+        self.stack_name = kwargs.get('name') or kwargs.get('stack_name') \
+                          or kwargs.get('client_name') or self.profile
+        self.force_new_session = kwargs.get('force_new_session', False)
 
         self.config = {}
 
@@ -87,7 +92,6 @@ class Client:
         self.stack_ = {}
         self.stack_entities = {}
         self.current_entities = {}
-        self.profile = kwargs.get('profile') or 'default'
         self.session = None
 
         try:
@@ -135,15 +139,25 @@ class Client:
                 self.credentials['token'] = self.token
                 self.credentials['host'] = self.host
 
+    def show_session_details(self):
+        """print the session details to the screen if debug"""
+        if self.debug:
+            print(f'Profile details: \n' +
+                  ",\n".join(["{}={}".format(key, val) for key, val in (self.credentials or {}).items()]))
+
     def _make_session(self, force_new=False):
         """ Create client session """
         # Search for the credentials if it wasnt provided in the class itself.
         if not self.token or not self.host:
             self._search_for_credentials()
+
         # Make new Rivery Session
         if force_new or not self.session:
             # Creating new Rivery Session
             logging.info(f'Connecting to host: {self.host or global_keys.DEFAULT_HOST}')
+            # print the session details to the screen if debug
+            self.show_session_details()
+
             self.session = RiverySession(token=self.token, host=self.host or global_keys.DEFAULT_HOST)
             self.session.connect()
             # self.session.list_connection_types()

--- a/rivery_cli/globals/global_settings.py
+++ b/rivery_cli/globals/global_settings.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.6"
+__version__ = "0.3.5"
 AVAILABE_RIVER_TYPES = ['logic']
 
 SCHEMA_VALIDATION_PATH = 'converters/schemas'

--- a/rivery_cli/globals/global_settings.py
+++ b/rivery_cli/globals/global_settings.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.4"
+__version__ = "0.3.6"
 AVAILABE_RIVER_TYPES = ['logic']
 
 SCHEMA_VALIDATION_PATH = 'converters/schemas'

--- a/tests/test_cli_rivers.py
+++ b/tests/test_cli_rivers.py
@@ -11,14 +11,14 @@ class Test(TestCase):
         self.runner = CliRunner(echo_stdin=True)
         self.runner.invoke(
             cli=base.cli,
-            args=['init', '--profile=test']
+            args=['--profile=test', 'init']
         )
 
     def test_import_rivers(self):
         """ Test import rivers """
 
         resp = self.runner.invoke(cli=base.cli,
-                                  args=['--profile=test', 'rivers', 'import', '--riverId=60005bb389f000001ef047aa', '--path=logics/'],
+                                  args=['--profile=test', '--debug', 'rivers', 'import', '--riverId=60005bb389f000001ef047aa', '--path=logics/'],
                                   catch_exceptions=False,
                                   color=True)
         print(resp.stdout)


### PR DESCRIPTION
There's a case in rivery rivers import + push that the profile name
passed incorrectly.

Therefore - made the next changes:

* Moved the debug printing into the "show_session_details" func on rivery client
* Changed the name being injected from profile if not passed
* Fix the name=... to profile=... on `rivery rivers` command