### PR TITLE
fix(links) - fix docs links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Rivery Command Line Tool (CLI)
 repo_url: https://github.com/RiveryIo/rivery_cli
 repo_name: RiveryIo/rivery_cli
 edit_uri: edit/docs/docs
-site_url: https://clidocs.rivery.io
+site_url: https://riveryio.github.io/rivery_cli/
 extra_css: 
   - stylesheets/rivery_light.css
 


### PR DESCRIPTION
in this link:
https://riveryio.github.io/rivery_cli/

the rivery icon refers to a broken link:
![image](https://user-images.githubusercontent.com/12347667/183689756-2d0d7b82-a488-45b5-90cc-3494bcc08d87.png)
